### PR TITLE
Update README.md for Advanced Vulnerability Assessment Tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,7 @@ gitpython
 prompt_toolkit
 pyyaml
 Flask
+python-nmap
+shodan
+pyOpenSSL
+reportlab


### PR DESCRIPTION
Update `requirements.txt` to include additional dependencies for the Advanced Vulnerability Assessment Tool.

* Add `python-nmap`, `shodan`, `pyOpenSSL`, and `reportlab` to the list of required Python packages.

